### PR TITLE
Resolving issue 9: Support for TOML Configuration File with -c and --config Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Before using this tool, make sure you have [Node.js](https://nodejs.org/) instal
 
 3. Install the required dependencies by running:
 
-
 ## Usage
 
 You can use this tool to convert text files to HTML with various options.
@@ -22,6 +21,7 @@ You can use this tool to convert text files to HTML with various options.
 ### Basic Usage
 
 To convert a single text file to HTML:
+
 ```bash
 node txtToHtml.js <input-file> [options]
 ```
@@ -31,9 +31,13 @@ node txtToHtml.js <input-file> [options]
 - `-o, --output <output-directory>`: Specify the output directory for the generated HTML files. If not specified, the default is `./til`.
 
   Example:
-```bash  
+
+```bash
 node txtToHtml.js ./example.txt -o ./output_folder
 ```
+
+- `-c`, `--config`: specify the file path to a TOML-based config file
+
 ### Additional Features
 
 #### Title Parsing
@@ -49,25 +53,28 @@ node txtToHtml.js ./example.txt -o ./output_folder
 Here are some usage examples:
 
 Convert a single text file and specify an output directory
+
 ```bash
 node txtToHtml.js ./example.txt -o ./custom_output
 ```
 
 Convert a directory of text files
+
 ```bash
 node txtToHtml.js ./text_files -o ./output
 ```
 
 Convert a text file with a specified stylesheet URL
+
 ```bash
 node txtToHtml.js ./example.txt -s https://example.com/styles.css
 ```
 
 Convert a text file or Markdown language from any language to CAD English
+
 ```bash
 node txtToHtml.js inputfile.txt -l fr til
 ```
-
 
 ## License
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+output = "./build"
+stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+lang = "fr"

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -415,6 +415,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "markdown-it": "^13.0.1",
         "mkdirp": "^3.0.1",
-        "rimraf": "^5.0.1"
+        "rimraf": "^5.0.1",
+        "toml": "^3.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -424,6 +425,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "markdown-it": "^13.0.1",
     "mkdirp": "^3.0.1",
-    "rimraf": "^5.0.1"
+    "rimraf": "^5.0.1",
+    "toml": "^3.0.0"
   }
 }

--- a/txtToHtml.js
+++ b/txtToHtml.js
@@ -42,9 +42,6 @@ function markdownToHtml(markdown, lang = 'en-CA') {
   return markdownIt.render(markdown);
 }
 
-  // Use markdown-it to render Markdown as HTML
-  return markdownIt.render(markdown);
-
 
 // Function to convert text to HTML with paragraphs
 function textToHtml(text) {

--- a/txtToHtml.js
+++ b/txtToHtml.js
@@ -1,12 +1,16 @@
-const fs = require('fs');
-const path = require('path');
-const mkdirp = require('mkdirp');
-const rimraf = require('rimraf'); // We'll use the 'rimraf' package to delete directories
-const markdownIt = require('markdown-it')(); // Require and initialize the markdown-it package
+const fs = require("fs");
+const path = require("path");
+const mkdirp = require("mkdirp");
+const rimraf = require("rimraf"); // We'll use the 'rimraf' package to delete directories
+const markdownIt = require("markdown-it")(); // Require and initialize the markdown-it package
+const toml = require("toml"); // Use a TOML library for parsing config files
 
 // Function to convert text to HTML with paragraphs
-function textToHtml(text, lang = 'en-CA') {
-  const paragraphs = text.split('\n\n').map(para => `<p>${para.trim()}</p>`).join('\n');
+function textToHtml(text, lang = "en-CA") {
+  const paragraphs = text
+    .split("\n\n")
+    .map((para) => `<p>${para.trim()}</p>`)
+    .join("\n");
   return `<!DOCTYPE html>
 <html lang="${lang}">
 <head>
@@ -21,16 +25,16 @@ function textToHtml(text, lang = 'en-CA') {
 }
 
 // Function to convert Markdown to HTML
-function markdownToHtml(markdown, lang = 'en-CA') {
+function markdownToHtml(markdown, lang = "en-CA") {
   // Configure markdown-it for rendering bold text with double asterisks or double underscores
-  markdownIt.use(require('markdown-it-container'), 'hljs', {
+  markdownIt.use(require("markdown-it-container"), "hljs", {
     render: (tokens, idx) => {
       if (tokens[idx].nesting === 1) {
         // Opening tag for a block of highlighted code
         return '<div class="hljs">';
       } else {
         // Closing tag for a block of highlighted code
-        return '</div>';
+        return "</div>";
       }
     },
   });
@@ -42,10 +46,12 @@ function markdownToHtml(markdown, lang = 'en-CA') {
   return markdownIt.render(markdown);
 }
 
-
 // Function to convert text to HTML with paragraphs
 function textToHtml(text) {
-  const paragraphs = text.split('\n\n').map(para => `<p>${para.trim()}</p>`).join('\n');
+  const paragraphs = text
+    .split("\n\n")
+    .map((para) => `<p>${para.trim()}</p>`)
+    .join("\n");
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -64,18 +70,18 @@ function processFile(inputFile, outputDir) {
   try {
     const fileExtension = path.extname(inputFile);
 
-    if (fileExtension === '.txt') {
+    if (fileExtension === ".txt") {
       // Read and convert text files to HTML
-      const txtContent = fs.readFileSync(inputFile, 'utf-8');
+      const txtContent = fs.readFileSync(inputFile, "utf-8");
       const htmlContent = textToHtml(txtContent);
-      const outputFileName = `${path.basename(inputFile, '.txt')}.html`;
+      const outputFileName = `${path.basename(inputFile, ".txt")}.html`;
       const outputPath = path.join(outputDir, outputFileName);
       fs.writeFileSync(outputPath, htmlContent);
-    } else if (fileExtension === '.md') {
+    } else if (fileExtension === ".md") {
       // Read and convert Markdown files to HTML
-      const mdContent = fs.readFileSync(inputFile, 'utf-8');
+      const mdContent = fs.readFileSync(inputFile, "utf-8");
       const htmlContent = markdownToHtml(mdContent);
-      const outputFileName = `${path.basename(inputFile, '.md')}.html`;
+      const outputFileName = `${path.basename(inputFile, ".md")}.html`;
       const outputPath = path.join(outputDir, outputFileName);
       fs.writeFileSync(outputPath, htmlContent);
     } else {
@@ -87,7 +93,6 @@ function processFile(inputFile, outputDir) {
     console.error(`Error: ${err.message}`);
   }
 }
-
 
 // Function to process a directory of .txt files
 function processDirectory(inputDir, outputDir) {
@@ -102,8 +107,8 @@ function processDirectory(inputDir, outputDir) {
     const files = fs.readdirSync(inputDir);
 
     // Process each .txt file
-    files.forEach(file => {
-      if (file.endsWith('.txt')) {
+    files.forEach((file) => {
+      if (file.endsWith(".txt")) {
         const inputFile = path.join(inputDir, file);
         processFile(inputFile, outputDir);
       }
@@ -118,25 +123,34 @@ function main() {
   try {
     const args = process.argv.slice(2);
 
-    if (args.length < 1) {
-      console.error('Usage: node txtToHtml.js <input-file-or-directory> [output-directory] [-l|--lang <language>]');
-      process.exit(1); // Exit with an error code
-    }
-
-    let lang = 'en-CA'; // Default language
+    let lang = "en-CA"; // Default language
+    let outputDir = "./til"; // Default output directory
 
     // Parse command line arguments
     for (let i = 0; i < args.length; i++) {
-      if (args[i] === '-l' || args[i] === '--lang') {
-        lang = args[i + 1] || 'en-CA';
+      if (args[i] === "-c" || args[i] === "--config") {
+        // Use config file
+        const configFile = args[i + 1];
+        const configData = fs.readFileSync(configFile, "utf-8");
+        const config = toml.parse(configData);
+
+        if (config.output) {
+          outputDir = config.output;
+        }
+
+        if (config.lang) {
+          lang = config.lang;
+        }
+
+        break; // Config file overrides other options
+      } else if (args[i] === "-l" || args[i] === "--lang") {
+        lang = args[i + 1] || "en-CA";
         // Skip the next argument as it has been processed as the language
         i++;
       }
     }
 
-    const inputPath = args.find(arg => !arg.startsWith('-'));
-    const outputDirIndex = args.indexOf('-l') !== -1 ? args.indexOf('-l') + 2 : args.indexOf('--lang') !== -1 ? args.indexOf('--lang') + 2 : args.indexOf(inputPath) + 1;
-    const outputDir = args[outputDirIndex] || './til';
+    const inputPath = args.find((arg) => !arg.startsWith("-"));
 
     if (fs.existsSync(inputPath)) {
       if (fs.lstatSync(inputPath).isDirectory()) {
@@ -144,10 +158,10 @@ function main() {
       } else {
         processFile(inputPath, outputDir, lang);
       }
-      console.log('Conversion completed successfully.');
+      console.log("Conversion completed successfully.");
       process.exit(0); // Exit with success code
     } else {
-      console.error('Error: Input file or directory not found.');
+      console.error("Error: Input file or directory not found.");
       process.exit(1); // Exit with an error code
     }
   } catch (error) {
@@ -162,18 +176,18 @@ function processFile(inputFile, outputDir, lang) {
     const fileExtension = path.extname(inputFile);
     let outputPath;
 
-    if (fileExtension === '.txt') {
+    if (fileExtension === ".txt") {
       // Read and convert text files to HTML
-      const txtContent = fs.readFileSync(inputFile, 'utf-8');
+      const txtContent = fs.readFileSync(inputFile, "utf-8");
       const htmlContent = textToHtml(txtContent, lang);
-      const outputFileName = `${path.basename(inputFile, '.txt')}.html`;
+      const outputFileName = `${path.basename(inputFile, ".txt")}.html`;
       outputPath = path.join(outputDir, outputFileName);
       fs.writeFileSync(outputPath, htmlContent);
-    } else if (fileExtension === '.md') {
+    } else if (fileExtension === ".md") {
       // Read and convert Markdown files to HTML
-      const mdContent = fs.readFileSync(inputFile, 'utf-8');
+      const mdContent = fs.readFileSync(inputFile, "utf-8");
       const htmlContent = markdownToHtml(mdContent);
-      const outputFileName = `${path.basename(inputFile, '.md')}.html`;
+      const outputFileName = `${path.basename(inputFile, ".md")}.html`;
       outputPath = path.join(outputDir, outputFileName);
       fs.writeFileSync(outputPath, htmlContent);
     } else {
@@ -185,7 +199,6 @@ function processFile(inputFile, outputDir, lang) {
     console.error(`Error: ${err.message}`);
   }
 }
-
 
 // Function to process a directory of .txt files with language parameter
 function processDirectory(inputDir, outputDir, lang) {
@@ -200,8 +213,8 @@ function processDirectory(inputDir, outputDir, lang) {
     const files = fs.readdirSync(inputDir);
 
     // Process each .txt file
-    files.forEach(file => {
-      if (file.endsWith('.txt')) {
+    files.forEach((file) => {
+      if (file.endsWith(".txt")) {
         const inputFile = path.join(inputDir, file);
         processFile(inputFile, outputDir, lang);
       }


### PR DESCRIPTION
Hello,

Description:
This enhancement aims to introduce support for TOML configuration files using the -c and --config flags. Users will be able to specify various options in a TOML formatted configuration file, simplifying command line usage and allowing for defaults when necessary. The program should gracefully handle missing or incorrectly formatted files.

**Acceptance criteria:**

- [x] The `-c `or `--config` flags accept a file path to a TOML-based config file.
- [x]  If the file is missing, or can't be parsed as `TOML`, exit with an appropriate error message.
- [x] If the `-c` or `--config` option is provided, ignore all other options (i.e., a config file overrides other options on the command line).
- [x] The program should ignore any options in the config file it doesn't recognize. For example, if the app doesn't support stylesheets, ignore a stylesheet property.
- [x] If the config file is missing any options, assume the usual defaults.